### PR TITLE
RemoteNotification should search for values in "aps" dictionary instead of top level

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
   gem 'cocoapods', '1.0.0'
+  gem 'activesupport', '~> 4.0'
 end

--- a/Sources/RemoteNotification.swift
+++ b/Sources/RemoteNotification.swift
@@ -42,6 +42,8 @@ public struct RemoteNotification: CustomStringConvertible, Equatable {
             return nil
         }
         
+        // Parse the notification payload.
+        // See https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html for more information on expected values.
         alert = Alert(remoteNotification: remoteNotification)
         
         let apnsDictionary = remoteNotification[APSServiceKey] as? [String : AnyObject]
@@ -87,8 +89,13 @@ public struct RemoteNotification: CustomStringConvertible, Equatable {
         public let wearableTitleLocalizationArguments: [String]?
         
         init?(remoteNotification: [String : AnyObject]) {
+            // Alert is represented as either a dictionary or a single string.
             guard let alert = remoteNotification[APSServiceKey]?[alertKey] as? [String : AnyObject] else {
-                body = remoteNotification[APSServiceKey]?[alertKey] as? String
+                guard let body = remoteNotification[APSServiceKey]?[alertKey] as? String else {
+                    return nil
+                }
+                
+                self.body = body
                 
                 bodyLocalizationKey = nil
                 bodyLocalizationArguments = nil

--- a/SuperDelegate.podspec
+++ b/SuperDelegate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'SuperDelegate'
-  s.version  = '0.8.0'
+  s.version  = '0.8.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'SuperDelegate provides a clean application delegate interface and protects you from bugs in the application lifecycle.'
   s.homepage = 'https://github.com/square/SuperDelegate'

--- a/Tests/RemoteNotificationTests.swift
+++ b/Tests/RemoteNotificationTests.swift
@@ -25,20 +25,22 @@ class RemoteNotificationTests: XCTestCase {
     
     func test_RemoteNotification_initWithFullRemoteNotificationDictionary() {
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -85,12 +87,56 @@ class RemoteNotificationTests: XCTestCase {
         XCTAssertNotEqual(remoteNotification, RemoteNotification(remoteNotification: differentRemoteNotificationDictionary))
     }
     
+    func test_RemoteNotification_initWithSimpleAlertRemoteNotificationDictionary() {
+        let remoteNotificationDictionary: [NSObject : AnyObject] = [
+            APSServiceKey : [
+                alertKey : alertBody,
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
+            ],
+            userInfoCustomKey1 : userInfoCustomValue1,
+            userInfoCustomKey2 : userInfoCustomValue2,
+            userInfoCustomKey3 : userInfoCustomValue3
+        ]
+        
+        guard let remoteNotification = RemoteNotification(remoteNotification: remoteNotificationDictionary) else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(alertBody, remoteNotification.alert?.body)
+        XCTAssertEqual(nil, remoteNotification.alert?.bodyLocalizationKey)
+        XCTAssertEqual(nil, remoteNotification.alert?.bodyLocalizationArguments?.first)
+        XCTAssertEqual(nil, remoteNotification.alert?.launchImageName)
+        XCTAssertEqual(nil, remoteNotification.alert?.wearableTitle)
+        XCTAssertEqual(nil, remoteNotification.alert?.wearableTitleLocalizationKey)
+        XCTAssertEqual(nil, remoteNotification.alert?.wearableTitleLocalizationArguments?.first)
+        
+        XCTAssertEqual(badge, remoteNotification.badge)
+        XCTAssertEqual(sound, remoteNotification.sound)
+        XCTAssertTrue(remoteNotification.contentAvailable)
+        XCTAssertEqual(categoryIdentifier, remoteNotification.categoryIdentifier)
+        XCTAssertEqual(remoteNotification.userInfo.count, 3)
+        XCTAssertEqual(remoteNotification.userInfo[userInfoCustomKey1] as? String, userInfoCustomValue1)
+        XCTAssertEqual(remoteNotification.userInfo[userInfoCustomKey2] as? String, userInfoCustomValue2)
+        XCTAssertEqual(remoteNotification.userInfo[userInfoCustomKey3] as? Int, userInfoCustomValue3)
+        
+        XCTAssertTrue(remoteNotification == RemoteNotification(remoteNotification: remoteNotificationDictionary)!)
+        var differentRemoteNotificationDictionary = remoteNotificationDictionary
+        differentRemoteNotificationDictionary[userInfoCustomKey3 + "many different"] = "wow"
+        XCTAssertNotEqual(remoteNotification, RemoteNotification(remoteNotification: differentRemoteNotificationDictionary))
+    }
+    
     func test_RemoteNotification_initWithSilentRemoteNotificationDictionary() {
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
+            APSServiceKey : [
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
+            ],
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -119,15 +165,27 @@ class RemoteNotificationTests: XCTestCase {
         XCTAssertEqual(remoteNotification.userInfo[userInfoCustomKey3] as? Int, userInfoCustomValue3)
         
         XCTAssertTrue(remoteNotification == RemoteNotification(remoteNotification: remoteNotificationDictionary)!)
-        var differentRemoteNotificationDictionary = remoteNotificationDictionary
-        differentRemoteNotificationDictionary.removeValueForKey(categoryKey)
+        let differentRemoteNotificationDictionary: [NSObject : AnyObject] = [
+            APSServiceKey : [
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                // Note that categoryKey is missing.
+            ],
+            userInfoCustomKey1 : userInfoCustomValue1,
+            userInfoCustomKey2 : userInfoCustomValue2,
+            userInfoCustomKey3 : userInfoCustomValue3
+        ]
+
         XCTAssertNotEqual(remoteNotification, RemoteNotification(remoteNotification: differentRemoteNotificationDictionary))
     }
     
     func test_RemoteNotification_initWithBadgeChangeRemoteNotificationDictionary() {
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            badgeKey : badge,
-            soundKey : sound,
+            APSServiceKey : [
+                badgeKey : badge,
+                soundKey : sound,
+            ],
         ]
         
         guard let remoteNotification = RemoteNotification(remoteNotification: remoteNotificationDictionary) else {

--- a/Tests/SuperDelegate+RemoteNotificationsTests.swift
+++ b/Tests/SuperDelegate+RemoteNotificationsTests.swift
@@ -48,20 +48,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_didFinishLaunchingWithOptions_loadsInterfaceWithRemoteNotification() {
         let remoteNotificationCapableDelegate = RemoteNotificationCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -87,20 +89,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_didReceiveRemoteNotification_deliversRemoteNotificationWithProperOrigin() {
         let remoteNotificationCapableDelegate = RemoteNotificationCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -135,20 +139,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_didReceiveRemoteNotification_dropsRemoteNotificationDeliveredToLoadInterfaceWithLaunchItem() {
         let remoteNotificationCapableDelegate = RemoteNotificationCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -182,20 +188,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_didReceiveRemoteNotification_doesNotDropRemoteNotificationDeliveredToLoadInterfaceWithLaunchItemAfterApplicationWillEnterForeground() {
         let remoteNotificationCapableDelegate = RemoteNotificationCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -231,20 +239,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_didReceiveRemoteNotification_doesNotDropRemoteNotificationDifferentThanRemoteNotificationDeliveredToLoadInterfaceWithLaunchItem() {
         let remoteNotificationCapableDelegate = RemoteNotificationCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -290,20 +300,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_receivingRemoteNotificationAction_notifies() {
         let remoteNotificationActionCapableDelegate = RemoteNotificationActionCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3
@@ -325,20 +337,22 @@ class SuperDelegateRemoteNotificationTests: SuperDelegateTests {
     func test_receivingLocalNotificationWithResponseInfoAction_notifies() {
         let remoteNotificationActionCapableDelegate = RemoteNotificationActionCapableDelegate()
         let remoteNotificationDictionary: [NSObject : AnyObject] = [
-            alertKey : [
-                alertBodyKey : alertBody,
-                alertBodyLocKey : alertBodyLocalizationKey,
-                alertBodyLocArgsKey : alertBodyLocalizationArgs,
-                alertActionLocKey : alertActionLocalizationKey,
-                alertLaunchImageKey : alertLaunchImageName,
-                alertWearableTitleKey : alertWearableTitle,
-                alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
-                alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+            APSServiceKey : [
+                alertKey : [
+                    alertBodyKey : alertBody,
+                    alertBodyLocKey : alertBodyLocalizationKey,
+                    alertBodyLocArgsKey : alertBodyLocalizationArgs,
+                    alertActionLocKey : alertActionLocalizationKey,
+                    alertLaunchImageKey : alertLaunchImageName,
+                    alertWearableTitleKey : alertWearableTitle,
+                    alertWearableTitleLocKey : alertWearableTitleLocalizationKey,
+                    alertWearableTitleLocArgsKey : alertWearableTitleLocalizationArgs
+                ],
+                badgeKey : badge,
+                soundKey : sound,
+                contentAvailableKey : contentAvailable,
+                categoryKey : categoryIdentifier,
             ],
-            badgeKey : badge,
-            soundKey : sound,
-            contentAvailableKey : contentAvailable,
-            categoryKey : categoryIdentifier,
             userInfoCustomKey1 : userInfoCustomValue1,
             userInfoCustomKey2 : userInfoCustomValue2,
             userInfoCustomKey3 : userInfoCustomValue3


### PR DESCRIPTION
cc @pwesten, @shawnwelch, @natan

Thanks @NinoScript for catching this!

Fixes #6