### PR TITLE
Add deprecation annotations so headers vended from SuperDelegate with…

### DIFF
--- a/Sources/SuperDelegate+LocalNotifications.swift
+++ b/Sources/SuperDelegate+LocalNotifications.swift
@@ -43,6 +43,7 @@ public protocol LocalNotificationActionCapable: LocalNotificationCapable {
 // MARK: - SuperDelegate Local Notification Extension
 
 
+@available(iOS, deprecated: 10.0)
 extension SuperDelegate {
     
     

--- a/Sources/SuperDelegate+UserNotifications.swift
+++ b/Sources/SuperDelegate+UserNotifications.swift
@@ -24,6 +24,7 @@ import Foundation
 // MARK: UserNotificationCapable – Opting into this protocol gives your app the ability to register for User Notifications. Adopt RemoteNotification or LocalNotification to actually receive notifications.
 
 
+@available(iOS, deprecated: 10.0)
 public protocol UserNotificationCapable: ApplicationLaunched {
     /// Called when your app registers for user notifications.
     func requestedUserNotificationSettings() -> UIUserNotificationSettings
@@ -135,7 +136,8 @@ extension SuperDelegate {
     
     // MARK: UIApplicationDelegate
     
-    
+
+    @available(iOS, deprecated: 10.0)
     @objc(application:didRegisterUserNotificationSettings:)
     final public func application(_ application: UIApplication, didRegister notificationSettings: UIUserNotificationSettings) {
         guard let userNotificationsCapableSelf = self as? UserNotificationCapable else {


### PR DESCRIPTION
… deprecated Apple classes throw consistent deprecation warnings in consumers